### PR TITLE
Changed logic to target lowest instead of highest.

### DIFF
--- a/automator.js
+++ b/automator.js
@@ -134,11 +134,11 @@ function startAutoTargetSwapper() {
 			}
 			
 			//Same type, prioritize by health remaining
-			else if(newTarget.m_data.hp < testMob.m_data.hp) {
+			else if(newTarget.m_data.hp > testMob.m_data.hp) {
 				setTarget = true;
 				
 				if(setTarget && debug)
-					console.log('Switching to a higher health target.');
+					console.log('Switching to a lower health target.');
 			}
 			
 			//If needed, overwrite the new target to the mob


### PR DESCRIPTION
After running the script for a bit and barely getting any income I believe if you always target the highest health mob the script will always attempt jump away before your mob dies unless it is the last of its type. This leads to significantly reduced income since it will often jump across lanes. Additionally it appears that the script detection relies on seeing if you change targets. They expect a human to be focused on a single target for the duration of the kill.
