### PR TITLE
fix autobuy & lower interval

### DIFF
--- a/automator.js
+++ b/automator.js
@@ -94,9 +94,6 @@ function startAutoUpgradeManager() {
 		return;
 	}
 	
-	autoUpgradeManager = setInterval(function() {
-		if(debug)
-			console.log('Checking for worthwhile upgrades');
 	  /************
 	   * SETTINGS *
 	   ************/
@@ -318,7 +315,9 @@ function startAutoUpgradeManager() {
 	  /********
 	   * MAIN *
 	   ********/
-	  return function() {
+	autoUpgradeManager = setInterval(function() {
+		if(debug)
+			console.log('Checking for worthwhile upgrades');
 		scene = g_Minigame.CurrentScene();
 		if (scene.m_bUpgradesBusy) return;
 		if (next.id === -1 || timeToDie() < survivalTime) updateNext();
@@ -333,7 +332,6 @@ function startAutoUpgradeManager() {
 			});
 		  }
 		}
-	  };
 	}, upgradeManagerFreq );
 	
 	console.log("autoUpgradeManager has been started.");

--- a/automator.js
+++ b/automator.js
@@ -284,17 +284,19 @@ function startAutoUpgradeManager() {
 
 	var timeToDie = (function() {
 		var lastLevel = 0;
-		var enemyDps;
+		var lastTime;
 		return function() {
 			var level = scene.m_rgGameData.level;
 			if (level !== lastLevel) {
-				enemyDps = scene.m_rgGameData.lanes.reduce(function(max, lane) {
+				var enemyDps = scene.m_rgGameData.lanes.reduce(function(max, lane) {
 					return Math.max(max, lane.enemies.reduce(function(sum, enemy) {
 						return sum + enemy.dps;
 					}, 0));
-				}, 0);
+				}, 0) || level * 4;
+				lastTime = scene.m_rgPlayerTechTree.max_hp / enemyDps;
 			}
-			return scene.m_rgPlayerTechTree.max_hp / (enemyDps || scene.m_rgGameData.level * 4 || 1);
+			lastLevel = level;
+			return lastTime;
 		};
 	})();
 

--- a/automator.js
+++ b/automator.js
@@ -21,7 +21,7 @@ var targetSwapperFreq = 1000;
 var abilityUseCheckFreq = 2000;
 var itemUseCheckFreq = 5000;
 var seekHealingPercent = 20;
-var upgradeManagerFreq = 30000;
+var upgradeManagerFreq = 5000;
 
 //item use variables
 var useMedicsAtPercent = 30;
@@ -282,15 +282,21 @@ function startAutoUpgradeManager() {
 		return best;
 	  };
 
-	  var timeToDie = function() {
-		var maxHp = scene.m_rgPlayerTechTree.max_hp;
-		var enemyDps = scene.m_rgGameData.lanes.reduce(function(max, lane) {
-		  return Math.max(max, lane.enemies.reduce(function(sum, enemy) {
-			return sum + enemy.dps;
-		  }, 0));
-		}, 0);
-		return maxHp / (enemyDps || scene.m_rgGameData.level * 4 || 1);
-	  };
+	var timeToDie = (function() {
+		var lastLevel = 0;
+		var enemyDps;
+		return function() {
+			var level = scene.m_rgGameData.level;
+			if (level !== lastLevel) {
+				enemyDps = scene.m_rgGameData.lanes.reduce(function(max, lane) {
+					return Math.max(max, lane.enemies.reduce(function(sum, enemy) {
+						return sum + enemy.dps;
+					}, 0));
+				}, 0);
+			}
+			return scene.m_rgPlayerTechTree.max_hp / (enemyDps || scene.m_rgGameData.level * 4 || 1);
+		};
+	})();
 
 	  var updateNext = function() {
 		next = necessaryUpgrade();


### PR DESCRIPTION
(Previously, the autobuyer wasn't even being executed.)

We can lower the interval because we're now caching `enemyDps`. A lower interval is nice (perhaps even 3 seconds would be better?) for a faster early game, because waiting 30 seconds between each upgrade on levels 1-10 is pretty awful.

Since we now cache `enemyDps` using the level number, this means that at most once per level, we iterate through each enemy in each lane. Otherwise, we perform this many computations during idle (i.e., waiting for a queued item to be affordable):
- Check `scene.m_bUpgradesBusy`
- Check `next.id` and `scene.m_rgGameData.level`
- Compute `scene.m_rgPlayerTechTree.max_hp / enemyDps`
- Check `next.cost <= scene.m_rgPlayerData.gold`

I think this is small enough to run much more often than once every thirty seconds.

---

TODO:
- Autobuying completely breaks if an upgrade fails to go through because `scene.m_bUpgradesBusy` does not get reset to false. How should we detect and handle this?
- If the user manually buys something, we don't currently recalculate the next upgrade to buy. We need to detect this in a way that won't break when reloading the script. my initial thought was to hook `CSceneGame::TryUpgrade` and set `next.id = -1` but we'll be doing this multiple times if the script is restarted. Technically, this shouldn't be too bad if we left it in, but it's not a pleasant approach.
- Crit (and Pumped Up?) should perhaps also trigger item recomputation, just to be sure.
- Smarter algorithm to determine whether to go grind towards unlocking an upgrade (i.e., account for the cost to unlock an upgrade rather than just ignoring locked upgrades).
