### PR TITLE
Added code for comboing Morale Booster, Good Luck Charm, and Decreased Cooldowns

### DIFF
--- a/automator.js
+++ b/automator.js
@@ -418,7 +418,7 @@ function startAutoAbilityUser() {
 		if(target)
 			targetPercentHPRemaining = target.m_data.hp  / target.m_data.max_hp * 100;
 		
-		// Moral Booster and Good Luck Charm
+		// Moral Booster, Good Luck Charm, and Decrease Cooldowns
 		if(hasAbility(5) || hasAbility(6)) {
 			// Only use on targets that are spawners and have nearly full health
 			if(target != undefined && target.m_data.type == 0 && targetPercentHPRemaining >= 80) {
@@ -461,18 +461,6 @@ function startAutoAbilityUser() {
 			}
 			
 		}
-		
-		// Decrease Cooldowns (doesn't stack, so make sure it's not already active)
-		//Temporarily disabled until we find a better trigger condition
-		/*
-		if(hasAbility(9) && !currentLaneHasAbility(9)) { 
-			// TODO: Any logic to using this?
-			if(debug)
-				console.log('Decreasing cooldowns.');
-			
-			castAbility(9);
-		}
-		*/
 		
 		// Tactical Nuke
 		if(target != undefined && target.m_data.type == 0 && targetPercentHPRemaining >= useNukeOnSpawnerAbovePercent) {

--- a/automator.js
+++ b/automator.js
@@ -462,7 +462,7 @@ function startAutoAbilityUser() {
                                 	                // Combo these with Decrease Cooldowns ability
 
                                         	        // If Decreased Cooldowns will be available soon, wait
-                                                	if(abilityIsUnlocked(9) && abilityCooldown(9) < 60) {
+                                                	if((abilityIsUnlocked(9) && abilityCooldown(9) < 60) || currentLaneHasAbility(9)) {
                                                         	if(hasAbility(9) && !currentLaneHasAbility(9)) {
                                                                 	// Other abilities won't benifit if used at the same time
 	                                                                castAbility(9);

--- a/automator.js
+++ b/automator.js
@@ -457,15 +457,16 @@ function startAutoAbilityUser() {
 
 	                                // "if Moral Booster isn't unlocked or Good Luck Charm isn't unlocked, or both are ready"
         	                        if(!moraleBoosterUnlocked || !goodLuckCharmUnlocked || (moraleBoosterReady && goodLuckCharmReady)) {
+						var currentLaneHasCooldown = currentLaneHasAbility(9);
                 	                        // Only use on targets that are spawners and have nearly full health
-                        	                if(targetPercentHPRemaining >= 70) {
+                        	                if(targetPercentHPRemaining >= 70 || (currentLaneHasCooldown && targetPercentHPRemaining >= 60)) {
                                 	                // Combo these with Decrease Cooldowns ability
 
                                         	        // If Decreased Cooldowns will be available soon, wait
 							if(
-							   currentLaneHasAbility(9) || // If current lane already has Decreased Cooldown, or
-							   !abilityIsUnlocked(9) ||    // if we haven't unlocked the ability yet, or
-							   (abilityCooldown(9) > 0 && abilityCooldown(9) < 60) // if cooldown > 0 seconds, but < 60
+							   currentLaneHasCooldown || // If current lane already has Decreased Cooldown, or
+							   !abilityIsUnlocked(9) ||  // if we haven't unlocked the ability yet, or
+							   (abilityCooldown(9) > 0 && abilityCooldown(9) < 60) // if cooldown > 0 seconds and < 60
 							  ) {
                                                         	if(hasAbility(9) && !currentLaneHasAbility(9)) {
                                                                 	// Other abilities won't benifit if used at the same time

--- a/automator.js
+++ b/automator.js
@@ -623,12 +623,16 @@ function laneHasAbility(lane, abilityID) {
 	return g_Minigame.m_CurrentScene.m_rgLaneData[lane].abilities[abilityID];
 }
 
+function abilityIsUnlocked(abilityID) {
+	return (1 << abilityID) & g_Minigame.CurrentScene().m_rgPlayerTechTree.unlocked_abilities_bitfield;
+}
+
 // thanks to /u/mouseasw for the base code: https://github.com/mouseas/steamSummerMinigame/blob/master/autoPlay.js
 function hasAbility(abilityID) {
 	// each bit in unlocked_abilities_bitfield corresponds to an ability.
 	// the above condition checks if the ability's bit is set or cleared. I.e. it checks if
 	// the player has purchased the specified ability.
-	return ((1 << abilityID) & g_Minigame.CurrentScene().m_rgPlayerTechTree.unlocked_abilities_bitfield) && g_Minigame.CurrentScene().GetCooldownForAbility(abilityID) <= 0;
+	return abilityIsUnlocked(abilityID) && g_Minigame.CurrentScene().GetCooldownForAbility(abilityID) <= 0;
 }
 
 function updateUserElementMultipliers() {

--- a/automator.js
+++ b/automator.js
@@ -485,13 +485,13 @@ function startAutoAbilityUser() {
 		}
 		
 		// Cluster Bomb
-		if(hasAbility(11)) { 
-			// TODO: Implement this
+		if(hasAbility(11) && !currentLaneHasAbility(11) && target.m_data.type == 0 && targetPercentHPRemaining >= 50) { 
+			castAbility(11);
 		}
 		
 		// Napalm
-		if(hasAbility(12)) { 
-			// TODO: Implement this
+		if(hasAbility(12) && !currentLaneHasAbility(11) && target.m_data.type == 0 && targetPercentHPRemaining >= 50) { 
+			castAbility(12);
 		}
 		
 	}, abilityUseCheckFreq);

--- a/automator.js
+++ b/automator.js
@@ -414,39 +414,7 @@ function startAutoAbilityUser() {
 		
 		var percentHPRemaining = g_Minigame.CurrentScene().m_rgPlayerData.hp  / g_Minigame.CurrentScene().m_rgPlayerTechTree.max_hp * 100;
 		var target = g_Minigame.m_CurrentScene.m_rgEnemies[g_Minigame.m_CurrentScene.m_rgPlayerData.target];
-		var targetPercentHPRemaining;
-		if(target)
-			targetPercentHPRemaining = target.m_data.hp  / target.m_data.max_hp * 100;
-		
-		// Moral Booster, Good Luck Charm, and Decrease Cooldowns
-		var moralBoosterReady = hasAbility(5);
-		var goodLuckCharmReady = hasAbility(6);
-		if(moralBoosterReady || goodLuckCharmReady) {
-			// If we have both we want to combo them
-			var moralBoosterUnlocked = abilityIsUnlocked(5);
-			var goodLuckCharmUnlocked = abilityIsUnlocked(6);
-			
-			// "if Moral Booster isn't unlocked or Good Luck Charm isn't unlocked, or both are ready"
-			if(!moralBoosterUnlocked || !goodLuckCharmUnlocked || (moralBoosterReady && goodLuckCharmReady)) {
-				// Only use on targets that are spawners and have nearly full health
-				if(target != undefined && target.m_data.type == 0 && targetPercentHPRemaining >= 75) {
-					// Combo with Decrease Cooldowns ability
 
-					// If Decreased Cooldowns will be available soon, wait
-					if(abilityIsUnlocked(9) && abilityCooldown(9) < 60) {
-						if(hasAbility(9) && !currentLaneHasAbility(9)) {
-							// Other abilities won't benifit if used at the same time
-							castAbility(9);
-						} else {
-							// Use these abilities next pass
-							castAbility(5);
-							castAbility(6);
-						}
-					}
-				}
-			}
-		}
-		
 		// Medics
 		if(percentHPRemaining <= useMedicsAtPercent && !g_Minigame.m_CurrentScene.m_bIsDead) {
 			if(debug)
@@ -461,37 +429,105 @@ function startAutoAbilityUser() {
 			else if(debug)
 				console.log("No medics to unleash!");
 		}
+
+		// Abilities only used on targets
+		if(target) {
+			var targetPercentHPRemaining = target.m_data.hp / target.m_data.max_hp * 100;
+		
+			// Moral Booster, Good Luck Charm, and Decrease Cooldowns
+			var moralBoosterReady = hasAbility(5);
+			var goodLuckCharmReady = hasAbility(6);
+			if(moralBoosterReady || goodLuckCharmReady) {
+				// If we have both we want to combo them
+				var moralBoosterUnlocked = abilityIsUnlocked(5);
+				var goodLuckCharmUnlocked = abilityIsUnlocked(6);
+				
+				// "if Moral Booster isn't unlocked or Good Luck Charm isn't unlocked, or both are ready"
+				if(!moralBoosterUnlocked || !goodLuckCharmUnlocked || (moralBoosterReady && goodLuckCharmReady)) {
+					// Only use on targets that are spawners and have nearly full health
+					if(target != undefined && target.m_data.type == 0 && targetPercentHPRemaining >= 75) {
+						// Combo with Decrease Cooldowns ability
+
+						// If Decreased Cooldowns will be available soon, wait
+						if(abilityIsUnlocked(9) && abilityCooldown(9) < 60) {
+							if(hasAbility(9) && !currentLaneHasAbility(9)) {
+								// Other abilities won't benifit if used at the same time
+								castAbility(9);
+							} else {
+								// Use these abilities next pass
+								castAbility(5);
+								castAbility(6);
+							}
+						}
+					}
+				}
+			}
+		
 	
-		// Metal Detector
-		if(target != undefined && target.m_data.type == 2 && targetPercentHPRemaining <= useMetalDetectorOnBossBelowPercent) {
-			if(hasAbility(8)) {
-				if(debug)
-					console.log('Using Metal Detector.');
-				
-				castAbility(8);
+			// Metal Detector
+			if(target.m_data.type == 2 && targetPercentHPRemaining <= useMetalDetectorOnBossBelowPercent) {
+				if(hasAbility(8)) {
+					if(debug)
+						console.log('Using Metal Detector.');
+					
+					castAbility(8);
+				}
 			}
 			
-		}
+			// Abilitys only used when targeting Spawners
+			if(target.m_data.type == 0) {
+
+	                        // Moral Booster, Good Luck Charm, and Decrease Cooldowns
+	                        var moralBoosterReady = hasAbility(5);
+        	                var goodLuckCharmReady = hasAbility(6);
+                	        if(moralBoosterReady || goodLuckCharmReady) {
+                        	        // If we have both we want to combo them
+                                	var moralBoosterUnlocked = abilityIsUnlocked(5);
+	                                var goodLuckCharmUnlocked = abilityIsUnlocked(6);
+
+	                                // "if Moral Booster isn't unlocked or Good Luck Charm isn't unlocked, or both are ready"
+        	                        if(!moralBoosterUnlocked || !goodLuckCharmUnlocked || (moralBoosterReady && goodLuckCharmReady)) {
+                	                        // Only use on targets that are spawners and have nearly full health
+                        	                if(targetPercentHPRemaining >= 70) {
+                                	                // Combo these with Decrease Cooldowns ability
+
+                                        	        // If Decreased Cooldowns will be available soon, wait
+                                                	if(abilityIsUnlocked(9) && abilityCooldown(9) < 60) {
+                                                        	if(hasAbility(9) && !currentLaneHasAbility(9)) {
+                                                                	// Other abilities won't benifit if used at the same time
+	                                                                castAbility(9);
+        	                                                } else {
+                	                                                // Use these abilities next pass
+                        	                                        castAbility(5);
+                                	                                castAbility(6);
+                                        	                }
+                                                	}
+	                                        }
+        	                        }
+                	        }
+
+
+				// Tactical Nuke
+				if(hasAbility(10) && targetPercentHPRemaining >= useNukeOnSpawnerAbovePercent) {
+					if(debug)
+						console.log('Nuclear launch detected.');
+					
+					castAbility(10);
+				}
+
 		
-		// Tactical Nuke
-		if(target != undefined && target.m_data.type == 0 && targetPercentHPRemaining >= useNukeOnSpawnerAbovePercent) {
-			if(hasAbility(10)) {
-				if(debug)
-					console.log('Nuclear launch detected.');
-				
-				castAbility(10);
+				// Cluster Bomb
+				if(hasAbility(11) && targetPercentHPRemaining >= 25) { 
+					castAbility(11);
+				}
+
+		
+				// Napalm
+				if(hasAbility(12) && !currentLaneHasAbility(12) && targetPercentHPRemaining >= 50) { 
+					castAbility(12);
+				}
+
 			}
-			
-		}
-		
-		// Cluster Bomb
-		if(hasAbility(11) && !currentLaneHasAbility(11) && target.m_data.type == 0 && targetPercentHPRemaining >= 50) { 
-			castAbility(11);
-		}
-		
-		// Napalm
-		if(hasAbility(12) && !currentLaneHasAbility(11) && target.m_data.type == 0 && targetPercentHPRemaining >= 50) { 
-			castAbility(12);
 		}
 		
 	}, abilityUseCheckFreq);

--- a/automator.js
+++ b/automator.js
@@ -431,13 +431,17 @@ function startAutoAbilityUser() {
 				// Only use on targets that are spawners and have nearly full health
 				if(target != undefined && target.m_data.type == 0 && targetPercentHPRemaining >= 75) {
 					// Combo with Decrease Cooldowns ability
-					if(hasAbility(9) && !currentLaneHasAbility(9)) {
-						// Other abilities won't benifit if used at the same time
-						castAbility(9);
-					} else {
-						// Use the abilities next pass
-						castAbility(5);
-						castAbility(6);
+
+					// If Decreased Cooldowns will be available soon, wait
+					if(abilityIsUnlocked(9) && abilityCooldown(9) < 60) {
+						if(hasAbility(9) && !currentLaneHasAbility(9)) {
+							// Other abilities won't benifit if used at the same time
+							castAbility(9);
+						} else {
+							// Use these abilities next pass
+							castAbility(5);
+							castAbility(6);
+						}
 					}
 				}
 			}
@@ -621,12 +625,17 @@ function abilityIsUnlocked(abilityID) {
 	return (1 << abilityID) & g_Minigame.CurrentScene().m_rgPlayerTechTree.unlocked_abilities_bitfield;
 }
 
+// Ability cooldown time remaining (in seconds)
+function abilityCooldown(abilityID) {
+	return g_Minigame.CurrentScene().GetCooldownForAbility(abilityID);
+}
+
 // thanks to /u/mouseasw for the base code: https://github.com/mouseas/steamSummerMinigame/blob/master/autoPlay.js
 function hasAbility(abilityID) {
 	// each bit in unlocked_abilities_bitfield corresponds to an ability.
 	// the above condition checks if the ability's bit is set or cleared. I.e. it checks if
 	// the player has purchased the specified ability.
-	return abilityIsUnlocked(abilityID) && g_Minigame.CurrentScene().GetCooldownForAbility(abilityID) <= 0;
+	return abilityIsUnlocked(abilityID) && abilityCooldown(abilityID) <= 0;
 }
 
 function updateUserElementMultipliers() {

--- a/automator.js
+++ b/automator.js
@@ -429,9 +429,11 @@ function startAutoAbilityUser() {
 						// Combo with decreased cooldowns
 						if (hasAbility(9) && !currentLaneHasAbility(9)) {
 							castAbility(9);
+						} else {
+							// Can't be cast at the same time as Decrease Cooldowns
+							castAbility(5);
+							castAbility(6);
 						}
-						castAbility(5);
-						castAbility(6);
 					}
 				}
 			}

--- a/automator.js
+++ b/automator.js
@@ -418,14 +418,23 @@ function startAutoAbilityUser() {
 		if(target)
 			targetPercentHPRemaining = target.m_data.hp  / target.m_data.max_hp * 100;
 		
-		// Morale Booster
-		if(hasAbility(5)) { 
-			// TODO: Implement this
-		}
-		
-		// Good Luck Charm
-		if(hasAbility(6)) { 
-			// TODO: Implement this
+		// Moral Booster and Good Luck Charm
+		if(hasAbility(5) || hasAbility(6)) {
+			// Don't use on bosses, we want to maximize gold
+			if(target.m_data.type != 2) {
+				// Don't use one if we don't have the other
+				if(!abilityIsUnlocked(5) || !abilityIsUnlocked(6) || (hasAbility(5) & hasAbility(6)) {
+					// Logic needs to go here to decide if the lane has enough health
+					if (true) {
+						// Combo with decreased cooldowns
+						if (hasAbility(9) && !currentLaneHasAbility(9)) {
+							castAbility(9);
+						}
+						castAbility(5);
+						castAbility(6);
+					}
+				}
+			}
 		}
 		
 		// Medics

--- a/automator.js
+++ b/automator.js
@@ -420,20 +420,17 @@ function startAutoAbilityUser() {
 		
 		// Moral Booster and Good Luck Charm
 		if(hasAbility(5) || hasAbility(6)) {
-			// Don't use on bosses, we want to maximize gold
-			if(target.m_data.type != 2) {
+			// Only use on targets that are spawners and have nearly full health
+			if(target != undefined && target.m_data.type == 0 && targetPercentHPRemaining >= 80) {
 				// Don't use one if we don't have the other
 				if(!abilityIsUnlocked(5) || !abilityIsUnlocked(6) || (hasAbility(5) & hasAbility(6))) {
-					// Logic needs to go here to decide if the lane has enough health
-					if (true) {
-						// Combo with decreased cooldowns
-						if (hasAbility(9) && !currentLaneHasAbility(9)) {
-							castAbility(9);
-						} else {
-							// Can't be cast at the same time as Decrease Cooldowns
-							castAbility(5);
-							castAbility(6);
-						}
+					// Combo with decreased cooldowns
+					if (hasAbility(9) && !currentLaneHasAbility(9)) {
+						castAbility(9);
+					} else {
+						// Can't be cast at the same time as Decrease Cooldowns
+						castAbility(5);
+						castAbility(6);
 					}
 				}
 			}

--- a/automator.js
+++ b/automator.js
@@ -462,7 +462,11 @@ function startAutoAbilityUser() {
                                 	                // Combo these with Decrease Cooldowns ability
 
                                         	        // If Decreased Cooldowns will be available soon, wait
-                                                	if((abilityIsUnlocked(9) && abilityCooldown(9) < 60) || currentLaneHasAbility(9)) {
+							if(
+							   currentLaneHasAbility(9) || // If current lane already has Decreased Cooldown, or
+							   !abilityIsUnlocked(9) ||    // if we haven't unlocked the ability yet, or
+							   (abilityCooldown(9) > 0 && abilityCooldown(9) < 60) // if cooldown > 0 seconds, but < 60
+							  ) {
                                                         	if(hasAbility(9) && !currentLaneHasAbility(9)) {
                                                                 	// Other abilities won't benifit if used at the same time
 	                                                                castAbility(9);

--- a/automator.js
+++ b/automator.js
@@ -448,15 +448,15 @@ function startAutoAbilityUser() {
 			if(target.m_data.type == 0) {
 
 	                        // Moral Booster, Good Luck Charm, and Decrease Cooldowns
-	                        var moralBoosterReady = hasAbility(5);
+	                        var moraleBoosterReady = hasAbility(5);
         	                var goodLuckCharmReady = hasAbility(6);
-                	        if(moralBoosterReady || goodLuckCharmReady) {
+                	        if(moraleBoosterReady || goodLuckCharmReady) {
                         	        // If we have both we want to combo them
-                                	var moralBoosterUnlocked = abilityIsUnlocked(5);
+                                	var moraleBoosterUnlocked = abilityIsUnlocked(5);
 	                                var goodLuckCharmUnlocked = abilityIsUnlocked(6);
 
 	                                // "if Moral Booster isn't unlocked or Good Luck Charm isn't unlocked, or both are ready"
-        	                        if(!moralBoosterUnlocked || !goodLuckCharmUnlocked || (moralBoosterReady && goodLuckCharmReady)) {
+        	                        if(!moraleBoosterUnlocked || !goodLuckCharmUnlocked || (moraleBoosterReady && goodLuckCharmReady)) {
                 	                        // Only use on targets that are spawners and have nearly full health
                         	                if(targetPercentHPRemaining >= 70) {
                                 	                // Combo these with Decrease Cooldowns ability

--- a/automator.js
+++ b/automator.js
@@ -423,7 +423,7 @@ function startAutoAbilityUser() {
 			// Don't use on bosses, we want to maximize gold
 			if(target.m_data.type != 2) {
 				// Don't use one if we don't have the other
-				if(!abilityIsUnlocked(5) || !abilityIsUnlocked(6) || (hasAbility(5) & hasAbility(6)) {
+				if(!abilityIsUnlocked(5) || !abilityIsUnlocked(6) || (hasAbility(5) & hasAbility(6))) {
 					// Logic needs to go here to decide if the lane has enough health
 					if (true) {
 						// Combo with decreased cooldowns

--- a/automator.js
+++ b/automator.js
@@ -419,16 +419,23 @@ function startAutoAbilityUser() {
 			targetPercentHPRemaining = target.m_data.hp  / target.m_data.max_hp * 100;
 		
 		// Moral Booster, Good Luck Charm, and Decrease Cooldowns
-		if(hasAbility(5) || hasAbility(6)) {
-			// Only use on targets that are spawners and have nearly full health
-			if(target != undefined && target.m_data.type == 0 && targetPercentHPRemaining >= 80) {
-				// Don't use one if we don't have the other
-				if(!abilityIsUnlocked(5) || !abilityIsUnlocked(6) || (hasAbility(5) & hasAbility(6))) {
-					// Combo with decreased cooldowns
-					if (hasAbility(9) && !currentLaneHasAbility(9)) {
+		var moralBoosterReady = hasAbility(5);
+		var goodLuckCharmReady = hasAbility(6);
+		if(moralBoosterReady || goodLuckCharmReady) {
+			// If we have both we want to combo them
+			var moralBoosterUnlocked = abilityIsUnlocked(5);
+			var goodLuckCharmUnlocked = abilityIsUnlocked(6);
+			
+			// "if Moral Booster isn't unlocked or Good Luck Charm isn't unlocked, or both are ready"
+			if(!moralBoosterUnlocked || !goodLuckCharmUnlocked || (moralBoosterReady && goodLuckCharmReady)) {
+				// Only use on targets that are spawners and have nearly full health
+				if(target != undefined && target.m_data.type == 0 && targetPercentHPRemaining >= 75) {
+					// Combo with Decrease Cooldowns ability
+					if(hasAbility(9) && !currentLaneHasAbility(9)) {
+						// Other abilities won't benifit if used at the same time
 						castAbility(9);
 					} else {
-						// Can't be cast at the same time as Decrease Cooldowns
+						// Use the abilities next pass
 						castAbility(5);
 						castAbility(6);
 					}

--- a/automator.js
+++ b/automator.js
@@ -624,7 +624,7 @@ function currentLaneHasAbility(abilityID) {
 }
 
 function laneHasAbility(lane, abilityID) {
-	return g_Minigame.m_CurrentScene.m_rgLaneData[lane].abilities[abilityID];
+	return typeof(g_Minigame.m_CurrentScene.m_rgLaneData[lane].abilities[abilityID]) != 'undefined';
 }
 
 function abilityIsUnlocked(abilityID) {

--- a/automator.js
+++ b/automator.js
@@ -434,36 +434,6 @@ function startAutoAbilityUser() {
 		if(target) {
 			var targetPercentHPRemaining = target.m_data.hp / target.m_data.max_hp * 100;
 		
-			// Moral Booster, Good Luck Charm, and Decrease Cooldowns
-			var moralBoosterReady = hasAbility(5);
-			var goodLuckCharmReady = hasAbility(6);
-			if(moralBoosterReady || goodLuckCharmReady) {
-				// If we have both we want to combo them
-				var moralBoosterUnlocked = abilityIsUnlocked(5);
-				var goodLuckCharmUnlocked = abilityIsUnlocked(6);
-				
-				// "if Moral Booster isn't unlocked or Good Luck Charm isn't unlocked, or both are ready"
-				if(!moralBoosterUnlocked || !goodLuckCharmUnlocked || (moralBoosterReady && goodLuckCharmReady)) {
-					// Only use on targets that are spawners and have nearly full health
-					if(target != undefined && target.m_data.type == 0 && targetPercentHPRemaining >= 75) {
-						// Combo with Decrease Cooldowns ability
-
-						// If Decreased Cooldowns will be available soon, wait
-						if(abilityIsUnlocked(9) && abilityCooldown(9) < 60) {
-							if(hasAbility(9) && !currentLaneHasAbility(9)) {
-								// Other abilities won't benifit if used at the same time
-								castAbility(9);
-							} else {
-								// Use these abilities next pass
-								castAbility(5);
-								castAbility(6);
-							}
-						}
-					}
-				}
-			}
-		
-	
 			// Metal Detector
 			if(target.m_data.type == 2 && targetPercentHPRemaining <= useMetalDetectorOnBossBelowPercent) {
 				if(hasAbility(8)) {


### PR DESCRIPTION
If you have Morale Booster and Good Luck Charm it will bring them in sync, since they combo well together and have the same cooldown time. It also tries to combo with Decreased Cooldowns if you have that. Also, if you use Decreased Cooldowns, you have to do it in a different update than the other abilities, or they won't get their cooldown reduction. Like the nuke code, this code won't combo on bosses.
