### PR TITLE
Add script name and version number to breadcrumbs

### DIFF
--- a/automator.user.js
+++ b/automator.user.js
@@ -1398,6 +1398,15 @@ function addCustomButtons() {
 		element.style.textShadow = '1px 1px 0px rgba( 0, 0, 0, 0.3 )';
 		element.textContent = 'Room ' + g_GameID;
 		breadcrumbs.appendChild(element);
+      
+		if(GM_info) {
+			element = document.createElement('span');
+			element.style.float = 'right';
+			element.style.color = '#D4E157';
+			element.style.textShadow = '1px 1px 0px rgba( 0, 0, 0, 0.3 )';
+			element.textContent = GM_info.script.name + ' v' + GM_info.script.version;
+			breadcrumbs.appendChild(element);
+		}
 	}
 }
 

--- a/automator.user.js
+++ b/automator.user.js
@@ -1399,7 +1399,7 @@ function addCustomButtons() {
 		element.textContent = 'Room ' + g_GameID;
 		breadcrumbs.appendChild(element);
       
-		if(GM_info) {
+		if(typeof GM_info != 'undefined') {
 			element = document.createElement('span');
 			element.style.float = 'right';
 			element.style.color = '#D4E157';


### PR DESCRIPTION
Minor change that adds the name and version of the script in the upper right corner on the same line as the breadcrumbs.  It will only work if the script is installed as a userscript as it relies on the GM_info object being defined.
