### PR TITLE
don't adjust crit_percentage for calculations

### DIFF
--- a/automator.user.js
+++ b/automator.user.js
@@ -335,7 +335,7 @@ function startAutoUpgradeManager() {
 		var dpc = scene.m_rgPlayerTechTree.damage_per_click;
 		var base_dpc = scene.m_rgTuningData.player.damage_per_click;
 		var critmult = scene.m_rgPlayerTechTree.damage_multiplier_crit;
-		var critrate = scene.m_rgPlayerTechTree.crit_percentage - scene.m_rgTuningData.player.crit_percentage;
+		var critrate = scene.m_rgPlayerTechTree.crit_percentage;
 		var elementals = getElementals();
 		var elementalCoefficient = getElementalCoefficient(elementals);
 

--- a/automator.user.js
+++ b/automator.user.js
@@ -335,7 +335,7 @@ function startAutoUpgradeManager() {
 		var dpc = scene.m_rgPlayerTechTree.damage_per_click;
 		var base_dpc = scene.m_rgTuningData.player.damage_per_click;
 		var critmult = scene.m_rgPlayerTechTree.damage_multiplier_crit;
-		var critrate = scene.m_rgPlayerTechTree.crit_percentage;
+		var critrate = Math.min(scene.m_rgPlayerTechTree.crit_percentage, 1);
 		var elementals = getElementals();
 		var elementalCoefficient = getElementalCoefficient(elementals);
 


### PR DESCRIPTION
The idea to reduce it by base `crit_percentage` stemmed from me noticing very few crits during a short testing session. I've [automated the test](https://gist.github.com/meishuu/17e48f90f8347a7ec403) and found that it's probably pretty reliable after all.

So we can stop adjusting it, and people with 100-110% crit will be guaranteed to never get elementals.

TODO: crit_percentage may need to be clamped to [0, 1] if the server doesn't already do that for us.
