### PR TITLE
Add refresh-stats button

### DIFF
--- a/automator.user.js
+++ b/automator.user.js
@@ -1522,11 +1522,11 @@ function addCustomButtons() {
 		element = document.createElement('span');
 		element.style.color = '#ACA5F2';
 		element.style.textShadow = '1px 1px 0px rgba( 0, 0, 0, 0.3 )';
-		element.innerHTML = 'Remaining Time: <span id="remaining_time">0 Seconds</span>.';
+		element.innerHTML = 'Remaining Time: <span id="remaining_time">0 Seconds</span> <a id="refresh_stats" title="Refresh Stats">&#x27f3;</a>';
 		breadcrumbs.appendChild(element);
 
 		updateStats();
-		setTimeout(function() { updateStats(); }, 10000);
+		$J("#refresh_stats").click (updateStats);
 
 		if(typeof GM_info != 'undefined') {
 			element = document.createElement('span');


### PR DESCRIPTION
Instead of updating stats timely (doesn't seem to work on
Chrome+Tampermonkey), use a refresh button instead. And a little less
work on the CPU.
