### PR TITLE
Auto-use wormholes

### DIFF
--- a/automator.user.js
+++ b/automator.user.js
@@ -652,6 +652,22 @@ function startAutoAbilityUser() {
 		
 		var currentLane = g_Minigame.m_CurrentScene.m_rgGameData.lanes[g_Minigame.CurrentScene().m_rgPlayerData.current_lane];
 		
+
+		// Wormholes -- use before wasting items on lanes
+		if (hasAbility(26) && autoUseConsumables) {
+			var nearEndWithTimeForWormholes = function() {
+				var time = new Date();
+				var hrs = time.getUTCHours();
+				var mins = time.getUTCMinutes();
+				return (hrs == 15 && (60 - mins) <= (getAbilityItemQuantity(26) + 5)); // give a little extra time to clear the last levels
+			};
+			if (nearEndWithTimeForWormholes()) {
+				if(debug)
+					console.log("Casting Wormhole! Allons-y!!!");
+				castAbility(26);
+			}
+		}
+
 		// Abilities only used on targets
 		if(target) {
 			
@@ -811,7 +827,7 @@ function startAutoAbilityUser() {
 				}
 			}
 		}
-		
+
 		//Estimate average player HP Percent in lane
 		var laneTotalPctHP = 0;
 		var laneTotalCount = 0;


### PR DESCRIPTION
Uses wormholes at the end of the room with only enough time to use however many the player has, plus an extra 5 minutes to clear bosses (disabled with auto-consumables off)
